### PR TITLE
Added Metrics Provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 
     compile 'commons-fileupload:commons-fileupload:1.4'
 
+    compile group: 'io.micrometer', name: 'micrometer-core', version: '1.5.5'
+
+
     testCompile "junit:junit:4.13"
     testCompile "org.hamcrest:hamcrest-all:1.3"
     testCompile("org.jmock:jmock:2.5.1") {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -139,7 +139,8 @@ public class WireMockApp implements StubServer, Admin {
             new BasicResponseRenderer(),
             options.getAdminAuthenticator(),
             options.getHttpsRequiredForAdminApi(),
-            getAdminRequestFilters()
+            getAdminRequestFilters(),
+          ImmutableList.copyOf(options.extensionsOfType(MeterRegistryProvider.class).values())
         );
     }
 
@@ -166,7 +167,8 @@ public class WireMockApp implements StubServer, Admin {
             postServeActions,
             requestJournal,
             getStubRequestFilters(),
-            options.getStubRequestLoggingDisabled()
+            options.getStubRequestLoggingDisabled(),
+          ImmutableList.copyOf(options.extensionsOfType(MeterRegistryProvider.class).values())
         );
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/MeterRegistryProvider.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/MeterRegistryProvider.java
@@ -1,0 +1,7 @@
+package com.github.tomakehurst.wiremock.extension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public interface MeterRegistryProvider extends Extension{
+  MeterRegistry getMeterRegistry();
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -15,12 +15,15 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.github.tomakehurst.wiremock.extension.MeterRegistryProvider;
 import com.github.tomakehurst.wiremock.extension.requestfilter.*;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.extension.requestfilter.FilterProcessor.processFilters;
@@ -32,10 +35,15 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
 	protected List<RequestListener> listeners = newArrayList();
 	protected final ResponseRenderer responseRenderer;
 	protected final List<RequestFilter> requestFilters;
+	protected MeterRegistry meterRegistry = null;
+  private static final String HTTP_SERVER_REQUESTS = "http.server.requests";
 
-	public AbstractRequestHandler(ResponseRenderer responseRenderer, List<RequestFilter> requestFilters) {
+	public AbstractRequestHandler(ResponseRenderer responseRenderer, List<RequestFilter> requestFilters, List<MeterRegistryProvider> meterRegistryProvider) {
 		this.responseRenderer = responseRenderer;
 		this.requestFilters = requestFilters;
+		if(!meterRegistryProvider.isEmpty()){
+			this.meterRegistry = meterRegistryProvider.get(0).getMeterRegistry();
+		}
 	}
 
 	@Override
@@ -82,6 +90,8 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
 
         beforeResponseSent(completedServeEvent, response);
 
+		//Publishing metrics
+		publishMetrics((double)stopwatch.elapsed(MILLISECONDS));
 		stopwatch.reset();
 		stopwatch.start();
 		httpResponder.respond(processedRequest, response);
@@ -116,4 +126,11 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
 	protected boolean logRequests() { return false; }
 
 	protected abstract ServeEvent handleRequest(Request request);
+
+	protected void publishMetrics(double latency){
+		if(meterRegistry != null) {
+			notifier().info("Publishing Metrics");
+			meterRegistry.summary(HTTP_SERVER_REQUESTS).record(latency);
+		}
+	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.common.NotPermittedException;
 import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.extension.MeterRegistryProvider;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -47,9 +48,10 @@ public class AdminRequestHandler extends AbstractRequestHandler {
                                ResponseRenderer responseRenderer,
                                Authenticator authenticator,
                                boolean requireHttps,
-                               List<RequestFilter> requestFilters
+                               List<RequestFilter> requestFilters,
+                             List<MeterRegistryProvider> meterRegistryProviders
     ) {
-		super(responseRenderer, requestFilters);
+		super(responseRenderer, requestFilters,meterRegistryProviders);
         this.adminRoutes = adminRoutes;
         this.admin = admin;
         this.authenticator = authenticator;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
@@ -17,11 +17,14 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.StubServer;
+import com.github.tomakehurst.wiremock.extension.MeterRegistryProvider;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.RequestJournal;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import java.util.List;
 import java.util.Map;
@@ -37,13 +40,14 @@ public class StubRequestHandler extends AbstractRequestHandler {
     private final boolean loggingDisabled;
 
 	public StubRequestHandler(StubServer stubServer,
-                              ResponseRenderer responseRenderer,
-                              Admin admin,
-                              Map<String, PostServeAction> postServeActions,
-                              RequestJournal requestJournal,
-                              List<RequestFilter> requestFilters,
-                              boolean loggingDisabled) {
-		super(responseRenderer, requestFilters);
+                            ResponseRenderer responseRenderer,
+                            Admin admin,
+                            Map<String, PostServeAction> postServeActions,
+                            RequestJournal requestJournal,
+                            List<RequestFilter> requestFilters,
+                            boolean loggingDisabled,
+                            List<MeterRegistryProvider> meterRegistryProvider) {
+		super(responseRenderer, requestFilters, meterRegistryProvider);
 		this.stubServer = stubServer;
         this.admin = admin;
         this.postServeActions = postServeActions;

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
@@ -19,6 +19,7 @@ import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.StubServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.MeterRegistryProvider;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
@@ -54,14 +55,15 @@ public class JettyHttpServerTest {
         context = new Mockery();
         Admin admin = context.mock(Admin.class);
 
-        adminRequestHandler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList());
+        adminRequestHandler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList(),Collections.<MeterRegistryProvider>emptyList());
         stubRequestHandler = new StubRequestHandler(context.mock(StubServer.class),
                 context.mock(ResponseRenderer.class),
                 admin,
                 Collections.<String, PostServeAction>emptyMap(),
                 context.mock(RequestJournal.class),
                 Collections.<RequestFilter>emptyList(),
-                false
+                false,
+          Collections.<MeterRegistryProvider>emptyList()
         );
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.extension.MeterRegistryProvider;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.*;
@@ -58,7 +59,7 @@ public class AdminRequestHandlerTest {
         httpResponder = new MockHttpResponder();
 
 
-		handler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList());
+		handler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList(), Collections.<MeterRegistryProvider>emptyList());
 	}
 	
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.StubServer;
+import com.github.tomakehurst.wiremock.extension.MeterRegistryProvider;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -67,7 +68,7 @@ public class StubRequestHandlerTest {
         admin = context.mock(Admin.class);
 		requestJournal = context.mock(RequestJournal.class);
 
-		requestHandler = new StubRequestHandler(stubServer, responseRenderer, admin, Collections.<String, PostServeAction>emptyMap(), requestJournal, Collections.<RequestFilter>emptyList(), false);
+		requestHandler = new StubRequestHandler(stubServer, responseRenderer, admin, Collections.<String, PostServeAction>emptyMap(), requestJournal, Collections.<RequestFilter>emptyList(), false, Collections.<MeterRegistryProvider>emptyList());
 
         context.checking(new Expectations() {{
             allowing(requestJournal);


### PR DESCRIPTION
Added MeterRegistryProvider as an extension which can be used for customizing and passing Micrometer MeterRegistry for publishing metrics.